### PR TITLE
Capture to escape

### DIFF
--- a/variationGenerator.js
+++ b/variationGenerator.js
@@ -57,18 +57,26 @@ function ladder(board, ladderedStone) {
 
 function getLiberties(cords, board) {
     const stoneColor = colorAt(cords, board);
+    const visited = new Set();
+    const queue = [cords];
+    const liberties = [];
 
-    return getNeighbors(cords)
-        .flatMap(cordToCheck => {
-            const colorAtCord = colorAt(cordToCheck, board);
+    while (queue.length > 0) {
+        const cordToCheck = queue.pop();
 
-            if (!colorAtCord) return [cordToCheck];
+        const key = `${cordToCheck[0]},${cordToCheck[1]}`;
+        if (visited.has(key)) continue;
+        visited.add(key);
 
-            return colorAtCord === stoneColor ?
-                getLiberties(cordToCheck, placeStone(cords, flipColor(stoneColor), board)) :
-                [];
-        })
-        .filter((a, i, liberties) => !liberties.slice(i + 1).some(b => a[0] === b[0] && a[1] === b[1]));
+        const colorAtCord = colorAt(cordToCheck, board);
+
+        if (!colorAtCord) {
+            liberties.push(cordToCheck);
+        } else if (colorAtCord === stoneColor) {
+            queue.push(...getNeighbors(cordToCheck));
+        }
+    }
+    return liberties;
 }
 
 function makeMove(color, cords, board) {

--- a/variationGenerator.js
+++ b/variationGenerator.js
@@ -175,11 +175,19 @@ function removeGroup(at, board) {
     );
 }
 
-function getNeighbors(cords) {
-    return [
-        [cords[0], cords[1] - 1],
-        [cords[0], cords[1] + 1],
-        [cords[0] + 1, cords[1]],
-        [cords[0] - 1, cords[1]]
-    ].filter(([x, y]) => x > 0 && x < 20 && y > 0 && y < 20);
+const NEIGHBORS = [];
+for (let x = 1; x <= 19; x++) {
+    NEIGHBORS.push([]);
+    for (let y = 1; y <= 19; y++) {
+        NEIGHBORS[x - 1].push([
+            [x, y - 1],
+            [x, y + 1],
+            [x + 1, y],
+            [x - 1, y]
+        ].filter(([a, b]) => a > 0 && a < 20 && b > 0 && b < 20));
+    }
+}
+
+function getNeighbors([x, y]) {
+    return NEIGHBORS[x - 1][y - 1];
 }


### PR DESCRIPTION
Doing a lot more search: this turned out to be very slow, so rewrote the "get neighbors" and "get liberties" operations so they're fast enough for the page to load.
Also, separated the "ladder" function into two different ones, one for the player trying to escape and one for the one who tries to capture. They had a lot of similar code but not sure how to merge them easily...

The slowest example I found when randomizing boards is
http://localhost:8000/?s=0&d=0&so=5%2C1&do=7%2C2&my=true&rc=true&rccw=true
in which it tries several other variations to capture the laddered stone after not making the last turn, continuing to 12,10 instead and then there are multiple variations where the surrounding stones get captured.

(btw thanks for the "share" option! it really helps when debugging this kind of logic)